### PR TITLE
Add bundler to ubuntu 18 04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ services:
 script:
 - docker build -t deifwpt/build-essential:14.04 build-essential/ubuntu-14.04
 - docker build -t deifwpt/build-essential:16.04 build-essential/ubuntu-16.04
+- docker build -t deifwpt/build-essential:18.04 build-essential/ubuntu-18.04
 - docker build -t deifwpt/dind docker/dind
 - docker build -t deifwpt/oe-lite oe-lite

--- a/build-essential/ubuntu-18.04/Dockerfile
+++ b/build-essential/ubuntu-18.04/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -qq \
 	doxygen \
 	libjansson-dev \
 	zlib1g-dev \
-	ruby \
+	ruby bundler \
 	ssmtp \
 	libnl-3-dev \
 	libnl-cli-3-dev libnl-genl-3-dev libnl-nf-3-dev libnl-route-3-dev \

--- a/build-essential/ubuntu-18.04/Dockerfile
+++ b/build-essential/ubuntu-18.04/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -qq \
 	doxygen \
 	libjansson-dev \
 	zlib1g-dev \
-	ruby bundler \
+	ruby ruby-dev bundler \
 	ssmtp \
 	libnl-3-dev \
 	libnl-cli-3-dev libnl-genl-3-dev libnl-nf-3-dev libnl-route-3-dev \


### PR DESCRIPTION
I thought that bundler now by default shipped with, but it is apparently not a part of `apt install ruby`